### PR TITLE
Fix add workflow summary screen

### DIFF
--- a/src/smart-components/workflow/summary_content.js
+++ b/src/smart-components/workflow/summary_content.js
@@ -21,11 +21,11 @@ const SummaryContent = (values) => {
       </TextContent>
       <TextContent>
         <Text className="data-table-detail heading" component={ TextVariants.h5 }>Approval Stages</Text>
-        { Object.keys(stages).map(key => key.startWith('stage') &&
+        { Object.keys(stages).map(key => key.startsWith('stage') &&
             <Text key={ key }
               className="data-table-detail content"
               component={ TextVariants.p }>
-              { key } : { values.groupOptions.find(group => group.value === stages[key]) }
+              { `${key} : ${values.groupOptions.find(group => group.value === stages[key]).label}` }
             </Text>) }
       </TextContent>
     </Fragment>


### PR DESCRIPTION
Follow up to #10.
Fix the display of the group names on the Add workflow summary screen wizard.
