### PR TITLE
Fix approval basename

### DIFF
--- a/config/base.webpack.config.js
+++ b/config/base.webpack.config.js
@@ -2,8 +2,6 @@
 
 const MiniCssExtractPlugin = require('mini-css-extract-plugin');
 const config = require('./webpack.common.js');
-const { resolve } = require('path');
-const pkg = require('../package.json');
 
 const webpackConfig = {
   mode: process.env.NODE_ENV === 'production' ? 'production' : 'development',
@@ -38,7 +36,7 @@ const webpackConfig = {
     }, {
       test: /\.s?[ac]ss$/,
       use: [
-        process.env.NODE_ENV === 'production' ? 'style-loader' : MiniCssExtractPlugin.loader,
+        MiniCssExtractPlugin.loader,
         {
           loader: 'css-loader'
         },

--- a/config/base.webpack.config.js
+++ b/config/base.webpack.config.js
@@ -7,6 +7,7 @@ const webpackConfig = {
   mode: process.env.NODE_ENV === 'production' ? 'production' : 'development',
   devtool: false,
   optimization: {
+    usedExports: true,
     minimize: process.env.NODE_ENV === 'production',
     splitChunks: {
       cacheGroups: {

--- a/config/spandx.config.js
+++ b/config/spandx.config.js
@@ -2,7 +2,7 @@
 
 module.exports = {
   routes: {
-    '/hybrid/approval': { host: `http://localhost:8002` },
+    '/hybrid/catalog/approval': { host: `http://localhost:8002` },
     '/apps/approval': { host: `http://localhost:8002` }
   }
 };

--- a/package.json
+++ b/package.json
@@ -117,5 +117,8 @@
   },
   "insights": {
     "appname": "approval"
-  }
+  },
+  "sideEffects": [
+    "*.scss"
+  ]
 }

--- a/src/entry-dev.js
+++ b/src/entry-dev.js
@@ -15,7 +15,7 @@ if (pathName[0] === 'beta') {
 
 ReactDOM.render(
   <Provider store={ store }>
-    <Router basename={ `${release}${pathName[0]}/${pathName[1]}` }>
+    <Router basename={ `${release}${pathName[0]}/${pathName[1]}/${pathName[2]}` }>
       <App />
     </Router>
   </Provider>,

--- a/src/entry.js
+++ b/src/entry.js
@@ -16,7 +16,7 @@ if (pathName[0] === 'beta') {
 
 ReactDOM.render(
   <Provider store={ store }>
-    <Router basename={ `${release}${pathName[0]}/${pathName[1]}` }>
+    <Router basename={ `${release}${pathName[0]}/${pathName[1]}/${pathName[2]}` }>
       <App />
     </Router>
   </Provider>,


### PR DESCRIPTION
Approval link has changed in chrome. I've updated the routing base path. https://github.com/RedHatInsights/insights-chrome/commit/0893997f1a7637ac4af013e267df82dc6049a184

Also it seems that approval has not been build in a week or so and the css stopped working like in catalog. It was quite odd that the same mistake did not show in approval UI event though it has identical build config.