### PR TITLE
Fix workflow edit for non-existing group stages

### DIFF
--- a/src/helpers/workflow/workflow-helper.js
+++ b/src/helpers/workflow/workflow-helper.js
@@ -12,7 +12,7 @@ export async function fetchWorkflowsWithGroups({ limit = 10, offset = 0 }) {
   let wfData = await workflowApi.listWorkflows(limit, offset);
   let workflows = wfData.data;
   return Promise.all(workflows.map(async wf => {
-    let wfWithGroups = wf.group_refs;
+    let wfWithGroups = [];
     try {
       wfWithGroups = await fetchGroupNames(wf.group_refs);
     }
@@ -30,7 +30,7 @@ export async function fetchWorkflowsWithGroups({ limit = 10, offset = 0 }) {
 
 export async function fetchWorkflowWithGroups(id) {
   let wfData = await workflowApi.showWorkflow(id);
-  let wfWithGroups = wfData.group_refs;
+  let wfWithGroups = [];
   try {
     wfWithGroups = await fetchGroupNames(wfData.group_refs);
   }

--- a/src/smart-components/workflow/add-workflow-modal.js
+++ b/src/smart-components/workflow/add-workflow-modal.js
@@ -33,7 +33,16 @@ const AddWorkflowModal = ({
     fetchWorkflow(id).then((data) => {
       let values = data.value;
       data.value.group_refs.forEach((group, idx) => {
-        values[`stage-${idx + 1}`] = group;
+        if (rbacGroups.find(rbacGroup => rbacGroup.value === group)) {
+          values[`stage-${idx + 1}`] = group;
+        }
+        else {
+          addNotification({
+            variant: 'warning',
+            title: 'Editing workflow',
+            description: `Stage-${idx + 1} group with id: ${group} no longer accessible`
+          });
+        }
       });
       setInitialValues(values);
     });

--- a/src/smart-components/workflow/expandable-content.js
+++ b/src/smart-components/workflow/expandable-content.js
@@ -13,7 +13,7 @@ const ExpandableContent = ({ description, groupRefs, groupNames }) => (
       <Text
         className="data-table-detail content"
         component={ TextVariants.h5 }>
-        { groupRefs.reduce((acc, curr, idx) => acc.concat(groupNames[idx] || curr), '') }
+        { groupRefs.reduce((acc, curr, idx) => acc.concat(`${(idx > 0) ? ',' : ''} ${groupNames[idx] || curr}`), '') }
       </Text>
     </TextContent>
   </Fragment>

--- a/src/smart-components/workflow/expandable-content.js
+++ b/src/smart-components/workflow/expandable-content.js
@@ -2,7 +2,7 @@ import React, { Fragment } from 'react';
 import PropTypes from 'prop-types';
 import { TextContent, Text, TextVariants } from '@patternfly/react-core';
 
-const ExpandableContent = ({ description, groups }) => (
+const ExpandableContent = ({ description, groupRefs, groupNames }) => (
   <Fragment>
     <TextContent>
       <Text className="data-table-detail heading" component={ TextVariants.small }>Description</Text>
@@ -13,7 +13,7 @@ const ExpandableContent = ({ description, groups }) => (
       <Text
         className="data-table-detail content"
         component={ TextVariants.h5 }>
-        { groups.join(',') }
+        { groupRefs.reduce((acc, curr, idx) => acc.concat(groupNames[idx] || curr), '') }
       </Text>
     </TextContent>
   </Fragment>
@@ -21,7 +21,8 @@ const ExpandableContent = ({ description, groups }) => (
 
 ExpandableContent.propTypes = {
   description: PropTypes.string,
-  groups: PropTypes.array
+  groupRefs: PropTypes.array.required,
+  groupNames: PropTypes.array.required
 };
 
 export default ExpandableContent;

--- a/src/smart-components/workflow/workflow-table-helpers.js
+++ b/src/smart-components/workflow/workflow-table-helpers.js
@@ -3,15 +3,15 @@ import React from 'react';
 import ExpandableContent from './expandable-content';
 
 export const createInitialRows = data =>
-  data.filter(item => item.name !== 'Always approve').reduce((acc, { id, name, description, group_names }, key) => ([
+  data.filter(item => item.name !== 'Always approve').reduce((acc, { id, name, description, group_refs, group_names }, key) => ([
     ...acc, {
       id,
       isOpen: false,
       selected: false,
-      cells: [ name, description, group_names.length ]
+      cells: [ name, description, group_refs.length ]
     }, {
       parent: key * 2,
-      cells: [{ title: <ExpandableContent description={ description } groups={ group_names } /> }]
+      cells: [{ title: <ExpandableContent description={ description } groupRefs={ group_refs } groupNames={ group_names } /> }]
     }
   ]), []);
 


### PR DESCRIPTION
For now, when a group(stage) no longer exist, the ui displays the group's uuid in the workflows list ( expanded content).
This PR clears the group uuid for a group that can no longer be accessed from the Edit Workflow Stage selection and displays a message for this stage/group.


![Screenshot from 2019-05-06 17-07-28](https://user-images.githubusercontent.com/12769982/57256278-37465300-7024-11e9-8649-68076cb56ef4.png)
![Screenshot from 2019-05-06 17-26-20](https://user-images.githubusercontent.com/12769982/57256282-3a414380-7024-11e9-8e7f-c7383716c3a2.png)
![Screenshot from 2019-05-06 17-26-31](https://user-images.githubusercontent.com/12769982/57256284-3ca39d80-7024-11e9-981f-197d683d1f11.png)
![Screenshot from 2019-05-06 17-26-41](https://user-images.githubusercontent.com/12769982/57256289-3f9e8e00-7024-11e9-8a66-3a9546a4b640.png)




