### PR TITLE
Update UI to match the Approval UI UX mocks - part 1

### DIFF
--- a/src/smart-components/app-tabs/app-tabs.js
+++ b/src/smart-components/app-tabs/app-tabs.js
@@ -3,7 +3,7 @@ import { withRouter } from 'react-router-dom';
 import PropTypes from 'prop-types';
 import { Tabs, Tab } from '@patternfly/react-core';
 
-const tabItems = [{ eventKey: 0, title: 'Requests', name: '/requests' }, { eventKey: 1, title: 'Workflows', name: '/workflows' }];
+const tabItems = [{ eventKey: 0, title: 'Request queue', name: '/requests' }, { eventKey: 1, title: 'Workflows', name: '/workflows' }];
 
 const AppTabs = ({ history: { push }, location: { pathname }}) => {
   const activeTab = tabItems.find(({ name }) => pathname.includes(name));

--- a/src/smart-components/request/requests.js
+++ b/src/smart-components/request/requests.js
@@ -60,8 +60,8 @@ const Requests = ({ fetchRequests, requests, pagination, history }) => {
         routes={ routes }
         actionResolver={ actionResolver }
         areActionsDisabled={ areActionsDisabled }
-        titlePlural="Requests"
-        titleSingular="Request"
+        titlePlural="requests"
+        titleSingular="request"
         pagination={ pagination }
       />
     </Fragment>;

--- a/src/smart-components/workflow/workflow-table-helpers.js
+++ b/src/smart-components/workflow/workflow-table-helpers.js
@@ -8,7 +8,7 @@ export const createInitialRows = data =>
       id,
       isOpen: false,
       selected: false,
-      cells: [ name, description, group_refs.length ]
+      cells: [ name, description ]
     }, {
       parent: key * 2,
       cells: [{ title: <ExpandableContent description={ description } groupRefs={ group_refs } groupNames={ group_names } /> }]

--- a/src/smart-components/workflow/workflows.js
+++ b/src/smart-components/workflow/workflows.js
@@ -15,8 +15,7 @@ const columns = [{
   title: 'Name',
   cellFormatters: [ expandable ]
 },
-'Description',
-'Groups'
+'Description'
 ];
 
 const Workflows = ({ fetchRbacGroups, fetchWorkflows, workflows, pagination, history }) => {
@@ -67,9 +66,9 @@ const Workflows = ({ fetchRbacGroups, fetchWorkflows, workflows, pagination, his
       <Link to="/workflows/add-workflow">
         <Button
           variant="primary"
-          aria-label="Create Workflow"
+          aria-label="Create workflow"
         >
-          Create Workflow
+          Create workflow
         </Button>
       </Link>
     </ToolbarItem>
@@ -99,8 +98,8 @@ const Workflows = ({ fetchRbacGroups, fetchWorkflows, workflows, pagination, his
         request={ fetchWorkflows }
         routes={ routes }
         actionResolver={ actionResolver }
-        titlePlural="Workflows"
-        titleSingular="Workflow"
+        titlePlural="workflows"
+        titleSingular="workflow"
         pagination={ pagination }
         setCheckedItems={ setCheckedWorkflows }
         toolbarButtons={ toolbarButtons }


### PR DESCRIPTION
Update UI to match the Approval UI UX mocks

1. Change ‘Requests’ to ‘Request queue’
2. Use sentence case for  ‘Find a workflow’ and  ‘Create workflow’
3. Remove Groups column from the workflows list

![Screenshot from 2019-06-19 15-25-04](https://user-images.githubusercontent.com/12769982/59794221-7532ca00-92a6-11e9-8a13-11fdb9844d4b.png)
